### PR TITLE
fix: using `os.sep` as the path separator "character"

### DIFF
--- a/makeSlides.py
+++ b/makeSlides.py
@@ -114,7 +114,7 @@ def add_text(images: list[str]):
         # get font
         font = ImageFont.truetype(PATH_FONT, FONT_SIZE)
         # get text
-        text = os.path.splitext(imagePath)[0].removeprefix("out\\")
+        text = os.path.splitext(imagePath)[0].removeprefix("out" + os.sep)
         # get wrapped text
         wrapped_text = get_wrapped_text(text, font, IMG_WIDTH*.75)
 


### PR DESCRIPTION
This addresses an issue on non-Windows environments where the output
directory is not removed from the text added to the image.